### PR TITLE
Fix verbose=2 throwing an error

### DIFF
--- a/src/SaddleSearch.jl
+++ b/src/SaddleSearch.jl
@@ -1,6 +1,7 @@
 module SaddleSearch
 
-using Parameters
+using Parameters, Dates
+import Dates: now
 
 export run!
 


### PR DESCRIPTION
`now()` not being imported means verbose output fails which makes understanding saddle searches difficult. This PR patches that by just explicitly importing it into the package.